### PR TITLE
Decouple fuel token from EVM proof

### DIFF
--- a/FuelToken.sol
+++ b/FuelToken.sol
@@ -10,21 +10,22 @@ contract FuelToken is ERC223Token {
     uint public decimals = 18; // any reason to use less?
     uint public totalSupply = 0;
     bytes32 public currentChallenge;
-    uint public _MINIMUM_TARGET = 2**16;
-    uint public _MAXIMUM_TARGET = 2**234;
+    uint public MINIMUM_TARGET = 2**16;
+    uint public MAXIMUM_TARGET = 2**234;
     
     event Mint(address miner, uint reward);
 
-    function mint(uint nonce) {
-        bytes8 n = bytes8(sha3(nonce, currentChallenge));
+    function mint(uint nonce) public {
+        bytes memory empty; // used for Event emit
+        uint256 n = uint256(keccak256(abi.encodePacked(nonce, currentChallenge)));
         // check that the minimum difficulty is met
-        require(n >= _MINIMUM_TARGET, "Minimum difficulty not met.");
+        require(n >= MINIMUM_TARGET, "Minimum difficulty not met.");
         // reward the mining difficulty - the number of zeros on the PoW solution
-        uint256 reward = _MAXIMUM_TARGET.div(n);
+        uint256 reward = MAXIMUM_TARGET.div(n);
         balances[msg.sender] += reward;
         totalSupply += reward;
         // update the challenge to prevent proof resubmission
-        currentChallenge = sha3(nonce, currentChallenge, block.blockhash(block.number - 1));
+        currentChallenge = keccak256(abi.encodePacked(nonce, currentChallenge, blockhash(block.number - 1)));
         
         // Event emmissions
         emit Transfer(0x0, msg.sender, reward);


### PR DESCRIPTION
Decouple fuel token issuance from parent EVM proof/difficulty, making it a fully independent proof of work fuel contract. Miners submit arbitrary solutions and are rewarded the applicable FuelTokens based on difficulty of the submitted solution.